### PR TITLE
[SUBS-1690] Add JWT to the ProcessingCertificateEnvelope

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'uk.ac.ebi.subs'
-version '1.2.1-SNAPSHOT'
+version '1.2.2-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'maven'
@@ -39,7 +39,7 @@ repositories {
 
 dependencies {
 
-    compile("uk.ac.ebi.subs:subs-processing-model:2.5.0-SNAPSHOT")
+    compile("uk.ac.ebi.subs:subs-processing-model:2.9.0-SNAPSHOT")
     compile("uk.ac.ebi.subs:subs-data-model:2.8.0-SNAPSHOT")
     compile("uk.ac.ebi.subs:subs-messaging:0.4.0-SNAPSHOT")
     compile("uk.ac.ebi.subs:validator-common:3.3.0-SNAPSHOT"){

--- a/src/main/java/uk/ac/ebi/subs/metabolights/agent/MetaboLightsStudyProcessor.java
+++ b/src/main/java/uk/ac/ebi/subs/metabolights/agent/MetaboLightsStudyProcessor.java
@@ -99,7 +99,8 @@ public class MetaboLightsStudyProcessor {
                 processingCertificate.setMessage(submissionEnvelope.getSubmission().getId() + " has no biostudies accession. This will prevent sending " +
                         "updates to metabolights. Please provide biostudies accession with this submission.");
                 processingCertificateList.add(processingCertificate);
-                return new ProcessingCertificateEnvelope(submissionEnvelope.getSubmission().getId(), processingCertificateList);
+                return new ProcessingCertificateEnvelope(
+                        submissionEnvelope.getSubmission().getId(), processingCertificateList, submissionEnvelope.getJWTToken());
             } else {
                 String mlStudyID = this.fetchService.getMLStudyID(study.getAccession());
                 if (AgentProcessorUtils.biostudiesIsAlreadyLinkedWith(mlStudyID)) {
@@ -110,7 +111,8 @@ public class MetaboLightsStudyProcessor {
                 }
             }
         }
-        return new ProcessingCertificateEnvelope(submissionEnvelope.getSubmission().getId(), processingCertificateList);
+        return new ProcessingCertificateEnvelope(
+                submissionEnvelope.getSubmission().getId(), processingCertificateList, submissionEnvelope.getJWTToken());
     }
 
     ProcessingCertificateEnvelope createNewMetaboLightsStudy(Study study, SubmissionEnvelope submissionEnvelope) {
@@ -128,12 +130,14 @@ public class MetaboLightsStudyProcessor {
         } catch (Exception e) {
             processingCertificate.setMessage("Error creating new study : " + e.getMessage());
             processingCertificateList.add(processingCertificate);
-            return new ProcessingCertificateEnvelope(submissionEnvelope.getSubmission().getId(), processingCertificateList);
+            return new ProcessingCertificateEnvelope(
+                    submissionEnvelope.getSubmission().getId(), processingCertificateList, submissionEnvelope.getJWTToken());
         }
         processingCertificateList.addAll(processMetaData(study, submissionEnvelope, true));
         processingCertificate.setProcessingStatus(ProcessingStatusEnum.Submitted);
         processingCertificateList.add(processingCertificate);
-        return new ProcessingCertificateEnvelope(submissionEnvelope.getSubmission().getId(), processingCertificateList);
+        return new ProcessingCertificateEnvelope(
+                submissionEnvelope.getSubmission().getId(), processingCertificateList, submissionEnvelope.getJWTToken());
     }
 
     List<ProcessingCertificate> processMetaData(Study study, SubmissionEnvelope submissionEnvelope, boolean isNewSubmission) {


### PR DESCRIPTION
We need to circulate the user's JWT tokens with the submission's dispatching loop. We need to add it to the ProcessingCertificate envelope, because that is the message that goes to submission's monitor listener and later to the submission's dispatcher.